### PR TITLE
feat(ST-49): integrate endpoint for sending message and ui for the global chat and add classDetails

### DIFF
--- a/modules/Classroom/components/ClassroomDetails/ClassroomDetails.interface.ts
+++ b/modules/Classroom/components/ClassroomDetails/ClassroomDetails.interface.ts
@@ -1,0 +1,5 @@
+import { Classroom } from "@/modules/Dasboard/components/ClassroomCardList/ClassroomCardList.types";
+
+export interface IClassroomDetailsProps {
+  classroom: Classroom;
+}

--- a/modules/Classroom/components/ClassroomDetails/ClassroomDetails.styles.ts
+++ b/modules/Classroom/components/ClassroomDetails/ClassroomDetails.styles.ts
@@ -1,0 +1,22 @@
+import { createStyles } from "@mantine/core";
+
+export const useStyles = createStyles((theme) => ({
+  paper: {
+    width: "100%",
+    padding: theme.spacing.md,
+    borderRadius: theme.radius.md,
+    border: `1px solid ${theme.colors.gray[3]}`,
+    boxShadow: theme.shadows.sm,
+  },
+  title: {
+    fontSize: theme.fontSizes.lg,
+    fontWeight: 700,
+    marginBottom: theme.spacing.sm,
+  },
+  label: {
+    fontWeight: 700,
+  },
+  text: {
+    fontSize: theme.fontSizes.sm,
+  },
+}));

--- a/modules/Classroom/components/ClassroomDetails/ClassroomDetails.tsx
+++ b/modules/Classroom/components/ClassroomDetails/ClassroomDetails.tsx
@@ -1,0 +1,32 @@
+import { Paper, Stack, Text } from "@mantine/core";
+import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
+
+import { IClassroomDetailsProps } from "./ClassroomDetails.interface";
+import { useStyles } from "./ClassroomDetails.styles";
+
+dayjs.extend(utc);
+
+const ClassroomDetails: React.FC<IClassroomDetailsProps> = ({ classroom }) => {
+  const { classes } = useStyles();
+
+  return (
+    <Paper className={classes.paper}>
+      <Stack spacing="xs">
+        <Text className={classes.title}>Details</Text>
+        <Text className={classes.text}>
+          <span className={classes.label}>Subject:</span> {classroom.subject}
+        </Text>
+        <Text className={classes.text}>
+          <span className={classes.label}>Class Time:</span>{" "}
+          {dayjs.utc(classroom.classTime).format("hh:mm A")}
+        </Text>
+        <Text className={classes.text}>
+          <span className={classes.label}>Days:</span> {classroom.days.join(", ")}
+        </Text>
+      </Stack>
+    </Paper>
+  );
+};
+
+export default ClassroomDetails;

--- a/modules/Classroom/components/SendMessageForm/SendMessageForm.helpers.ts
+++ b/modules/Classroom/components/SendMessageForm/SendMessageForm.helpers.ts
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export const SendMessageFormSchema = z
+  .object({
+    content: z.string().min(1, "You need to input a message in the text box"),
+  })
+  .strict();
+
+export type SendMessageFormValues = z.infer<typeof SendMessageFormSchema>;

--- a/modules/Classroom/components/SendMessageForm/SendMessageForm.interface.ts
+++ b/modules/Classroom/components/SendMessageForm/SendMessageForm.interface.ts
@@ -1,0 +1,7 @@
+export interface ISendMessageFormProps {
+  classroomId: number;
+}
+
+export interface ISendMessageFormValues {
+  content: string;
+}

--- a/modules/Classroom/components/SendMessageForm/SendMessageForm.tsx
+++ b/modules/Classroom/components/SendMessageForm/SendMessageForm.tsx
@@ -1,0 +1,69 @@
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Button, Group } from "@mantine/core";
+import { notifications } from "@mantine/notifications";
+import { Form, FormSubmitHandler, useForm } from "react-hook-form";
+import { Textarea } from "react-hook-form-mantine";
+
+import { useCreateMessageMutation } from "@/shared/redux/rtk-apis/messages/messages.api";
+
+import { SendMessageFormSchema, SendMessageFormValues } from "./SendMessageForm.helpers";
+import { ISendMessageFormProps, ISendMessageFormValues } from "./SendMessageForm.interface";
+
+const SendMessageForm: React.FC<ISendMessageFormProps> = ({ classroomId }) => {
+  const {
+    control,
+    reset,
+    formState: { errors },
+  } = useForm<ISendMessageFormValues>({
+    defaultValues: {
+      content: "",
+    },
+    resolver: zodResolver(SendMessageFormSchema),
+  });
+
+  const [createMessage] = useCreateMessageMutation();
+
+  const onSubmit: FormSubmitHandler<SendMessageFormValues> = async (formPayload) => {
+    try {
+      await createMessage({
+        content: formPayload.data.content,
+        classroomId: classroomId,
+      }).unwrap();
+
+      notifications.show({
+        color: "blue",
+        title: "Success",
+        message: "Message sent!",
+      });
+      reset();
+    } catch (error) {
+      notifications.show({
+        color: "red",
+        title: "Success",
+        message: "Failed to send message",
+      });
+    }
+  };
+
+  return (
+    <Form control={control} onSubmit={onSubmit}>
+      <Textarea
+        placeholder="Type your message here"
+        size="lg"
+        control={control}
+        name="content"
+        error={errors.content?.message}
+      />
+      <Group mt="md" position="right">
+        <Button size="sm" color="blue" onClick={() => reset()}>
+          Reset
+        </Button>
+        <Button size="sm" color="blue" type="submit">
+          Post
+        </Button>
+      </Group>
+    </Form>
+  );
+};
+
+export default SendMessageForm;

--- a/modules/Classroom/containers/StreamContainer/StreamContainer.interface.ts
+++ b/modules/Classroom/containers/StreamContainer/StreamContainer.interface.ts
@@ -1,0 +1,5 @@
+import { Classroom } from "@/modules/Dasboard/components/ClassroomCardList/ClassroomCardList.types";
+
+export interface IStreamContainerProps {
+  classroom: Classroom;
+}

--- a/modules/Classroom/containers/StreamContainer/StreamContainer.styles.ts
+++ b/modules/Classroom/containers/StreamContainer/StreamContainer.styles.ts
@@ -1,0 +1,29 @@
+import { createStyles } from "@mantine/core";
+
+export const useStyles = createStyles((theme) => ({
+  outerContainer: {
+    minHeight: "100vh",
+    width: "100%",
+    padding: `${theme.spacing.sm} 0`,
+  },
+  innerContainer: {
+    maxWidth: "99%",
+  },
+  detailsColumn: {
+    [theme.fn.smallerThan("md")]: {
+      display: "none",
+    },
+  },
+  formColumn: {
+    [theme.fn.largerThan("md")]: {
+      flexBasis: "75%",
+      maxWidth: "75%",
+    },
+  },
+  formWrapper: {
+    background: "white",
+    borderRadius: theme.radius.md,
+    boxShadow: theme.shadows.sm,
+    padding: theme.spacing.md,
+  },
+}));

--- a/modules/Classroom/containers/StreamContainer/StreamContainer.tsx
+++ b/modules/Classroom/containers/StreamContainer/StreamContainer.tsx
@@ -1,15 +1,33 @@
-import { Classroom } from "@/modules/Dasboard/components/ClassroomCardList/ClassroomCardList.types";
+import { Box, Container, Grid } from "@mantine/core";
 
+import ClassroomDetails from "../../components/ClassroomDetails/ClassroomDetails";
+import SendMessageForm from "../../components/SendMessageForm/SendMessageForm";
 import StreamHeader from "../../components/StreamHeader/StreamHeader";
+import { IStreamContainerProps } from "./StreamContainer.interface";
+import { useStyles } from "./StreamContainer.styles";
 
-interface StreamContainerProps {
-  classroom: Classroom;
-}
+const StreamContainer: React.FC<IStreamContainerProps> = ({ classroom }) => {
+  const { classes } = useStyles();
 
-const StreamContainer: React.FC<StreamContainerProps> = ({ classroom }) => (
-  <>
-    <StreamHeader classroom={classroom} />
-  </>
-);
+  return (
+    <Box>
+      <StreamHeader classroom={classroom} />
+      <Box className={classes.outerContainer}>
+        <Container className={classes.innerContainer}>
+          <Grid>
+            <Grid.Col span={3} className={classes.detailsColumn}>
+              <ClassroomDetails classroom={classroom} />
+            </Grid.Col>
+            <Grid.Col span={12} className={classes.formColumn}>
+              <Box className={classes.formWrapper}>
+                <SendMessageForm classroomId={classroom.id} />
+              </Box>
+            </Grid.Col>
+          </Grid>
+        </Container>
+      </Box>
+    </Box>
+  );
+};
 
 export default StreamContainer;

--- a/shared/redux/rtk-apis/messages/messages.api.ts
+++ b/shared/redux/rtk-apis/messages/messages.api.ts
@@ -1,0 +1,17 @@
+import { projectApi } from "../api.config";
+import { CreateMessageDto, IMessage } from "./messages.interface";
+
+const messagesApi = projectApi.injectEndpoints({
+  endpoints: (builder) => ({
+    createMessage: builder.mutation<IMessage, CreateMessageDto>({
+      query: (messageData) => ({
+        url: "/messages",
+        method: "POST",
+        body: messageData,
+      }),
+    }),
+  }),
+  overrideExisting: false,
+});
+
+export const { useCreateMessageMutation } = messagesApi;

--- a/shared/redux/rtk-apis/messages/messages.interface.ts
+++ b/shared/redux/rtk-apis/messages/messages.interface.ts
@@ -1,0 +1,15 @@
+export interface IMessage {
+  id: number;
+  content: string;
+  attachmentURL?: string;
+  senderId: number;
+  classroomId: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateMessageDto {
+  content: string;
+  attachmentURL?: string;
+  classroomId: number;
+}


### PR DESCRIPTION
## Description of Change
- Integrate the endpoint for sending messages files created for that "messages.api.ts" 
- Created SendMessage.tsx for sending messages
- Created ClassDetails component
- Updated the StreamContainer to import both ClassDetails component and SendMessage
- Added interface and styles on separate files for all the files

## Associated Ticket Link(s)

- https://trello.com/c/RUgEtG5m

## Screenshots / Screen Recordings

https://github.com/user-attachments/assets/d0cffd06-c1b5-4930-b3a4-83c5cde0ee5e



