### PR TITLE
feat(ST-167): integrate forget password enpoint and create multi-form

### DIFF
--- a/modules/Login/components/ForgetPasswordModal/ForgetPasswordModal.helpers.ts
+++ b/modules/Login/components/ForgetPasswordModal/ForgetPasswordModal.helpers.ts
@@ -1,0 +1,23 @@
+import { z } from "zod";
+
+export const emailSchema = z.object({
+  email: z.string().email({ message: "Invalid email address" }),
+});
+
+export const otpSchema = z.object({
+  otp: z.string().length(6, { message: "OTP must be 6 characters long" }),
+});
+
+export const passwordSchema = z
+  .object({
+    newPassword: z.string().min(8, { message: "Password must be at least 8 characters long" }),
+    confirmPassword: z.string(),
+  })
+  .refine((data) => data.newPassword === data.confirmPassword, {
+    message: "Passwords don't match",
+    path: ["confirmPassword"],
+  });
+
+export type TEmailFormValues = z.infer<typeof emailSchema>;
+export type TOtpFormValues = z.infer<typeof otpSchema>;
+export type TPasswordFormValues = z.infer<typeof passwordSchema>;

--- a/modules/Login/components/ForgetPasswordModal/ForgetPasswordModal.interface.ts
+++ b/modules/Login/components/ForgetPasswordModal/ForgetPasswordModal.interface.ts
@@ -1,0 +1,4 @@
+export interface IPasswordResetModalProps {
+  opened: boolean;
+  onClose: () => void;
+}

--- a/modules/Login/components/ForgetPasswordModal/ForgetPasswordModal.styles.ts
+++ b/modules/Login/components/ForgetPasswordModal/ForgetPasswordModal.styles.ts
@@ -1,0 +1,18 @@
+export const inputStyles = {
+  label: { color: "#4CAF50" },
+  input: { color: "#4CAF50" },
+};
+
+export const formStyles = {
+  title: {
+    marginBottom: 20,
+    fontWeight: 700,
+    textTransform: "uppercase",
+    fontSize: "lg",
+    color: "#4CAF50",
+  },
+  submitButton: {
+    backgroundColor: "#4CAF50",
+    color: "white",
+  },
+};

--- a/modules/Login/components/ForgetPasswordModal/ForgetPasswordModal.tsx
+++ b/modules/Login/components/ForgetPasswordModal/ForgetPasswordModal.tsx
@@ -1,0 +1,218 @@
+import { useState } from "react";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Modal, Button, Group, Box, TextInput, Text, PasswordInput } from "@mantine/core";
+import { showNotification } from "@mantine/notifications";
+import { useForm } from "react-hook-form";
+
+import {
+  useGenerateResetPasswordOtpMutation,
+  useResetPasswordMutation,
+  useValidateOtpMutation,
+} from "@/shared/redux/rtk-apis/auth/auth.api";
+
+import { ApiError } from "../../containers/LoginContainer.types";
+import {
+  emailSchema,
+  otpSchema,
+  passwordSchema,
+  TEmailFormValues,
+  TOtpFormValues,
+  TPasswordFormValues,
+} from "./ForgetPasswordModal.helpers";
+import { IPasswordResetModalProps } from "./ForgetPasswordModal.interface";
+import { inputStyles, formStyles } from "./ForgetPasswordModal.styles";
+
+const ForgetPasswordModal: React.FC<IPasswordResetModalProps> = ({ opened, onClose }) => {
+  const [step, setStep] = useState(1);
+  const [email, setEmail] = useState("");
+  const [otp, setOtp] = useState("");
+  const [generateOtp, { isLoading: isGeneratingOtp }] = useGenerateResetPasswordOtpMutation();
+  const [validateOtp, { isLoading: isValidatingOtp }] = useValidateOtpMutation();
+  const [resetPassword, { isLoading: isResettingPassword }] = useResetPasswordMutation();
+
+  const {
+    register: registerEmail,
+    handleSubmit: handleEmailSubmit,
+    formState: { errors: emailErrors },
+  } = useForm<TEmailFormValues>({
+    resolver: zodResolver(emailSchema),
+  });
+
+  const {
+    register: registerOtp,
+    handleSubmit: handleOtpSubmit,
+    formState: { errors: otpErrors },
+  } = useForm<TOtpFormValues>({
+    resolver: zodResolver(otpSchema),
+  });
+
+  const {
+    register: registerPassword,
+    handleSubmit: handlePasswordSubmit,
+    formState: { errors: passwordErrors },
+  } = useForm<TPasswordFormValues>({
+    resolver: zodResolver(passwordSchema),
+  });
+
+  const onEmailSubmit = async (data: TEmailFormValues) => {
+    try {
+      await generateOtp({ email: data.email }).unwrap();
+      setEmail(data.email);
+      setStep(2);
+      showNotification({
+        title: "Success",
+        message: "OTP sent to your email",
+        color: "blue",
+      });
+    } catch (error) {
+      showNotification({
+        title: "Error",
+        message: (error as ApiError).data?.message || "Failed to send OTP",
+        color: "red",
+      });
+    }
+  };
+
+  const onOtpSubmit = async (data: TOtpFormValues) => {
+    try {
+      const result = await validateOtp({ email, otp: data.otp }).unwrap();
+      if (result.isValid) {
+        setOtp(data.otp);
+        setStep(3);
+      } else {
+        showNotification({
+          title: "Error",
+          message: "Invalid OTP",
+          color: "red",
+        });
+      }
+    } catch (error) {
+      showNotification({
+        title: "Error",
+        message: (error as ApiError).data?.message || "Failed to validate OTP",
+        color: "red",
+      });
+    }
+  };
+
+  const onPasswordSubmit = async (data: TPasswordFormValues) => {
+    try {
+      await resetPassword({
+        email,
+        otp,
+        newPassword: data.newPassword,
+      }).unwrap();
+      showNotification({
+        title: "Success",
+        message: "Password reset successfully",
+        color: "blue",
+      });
+      onClose();
+    } catch (error) {
+      showNotification({
+        title: "Error",
+        message: (error as ApiError).data?.message || "Failed to reset password",
+        color: "red",
+      });
+    }
+  };
+
+  const handleCancel = () => {
+    setStep(1);
+    setEmail("");
+    setOtp("");
+    onClose();
+  };
+
+  return (
+    <Modal opened={opened} onClose={onClose} size="md" centered>
+      <Box mx="xl">
+        <Text mb={20} fw={700} tt="uppercase" size="lg" c="#4CAF50">
+          Reset Password
+        </Text>
+        {step === 1 && (
+          <form onSubmit={handleEmailSubmit(onEmailSubmit)}>
+            <TextInput
+              label="Email"
+              placeholder="Enter your email"
+              error={emailErrors.email?.message}
+              {...registerEmail("email")}
+              styles={inputStyles}
+            />
+            <Group mt="xl" mb="sm">
+              <Button size="sm" color="gray" onClick={handleCancel}>
+                Cancel
+              </Button>
+              <Button
+                type="submit"
+                size="sm"
+                style={formStyles.submitButton}
+                loading={isGeneratingOtp}
+              >
+                Send OTP
+              </Button>
+            </Group>
+          </form>
+        )}
+        {step === 2 && (
+          <form onSubmit={handleOtpSubmit(onOtpSubmit)}>
+            <TextInput
+              label="OTP"
+              placeholder="Enter the OTP sent to your email"
+              error={otpErrors.otp?.message}
+              {...registerOtp("otp")}
+              styles={inputStyles}
+            />
+            <Group mt="xl" mb="sm">
+              <Button size="sm" color="gray" onClick={() => setStep(1)}>
+                Back
+              </Button>
+              <Button
+                type="submit"
+                size="sm"
+                style={formStyles.submitButton}
+                loading={isValidatingOtp}
+              >
+                Verify OTP
+              </Button>
+            </Group>
+          </form>
+        )}
+        {step === 3 && (
+          <form onSubmit={handlePasswordSubmit(onPasswordSubmit)}>
+            <PasswordInput
+              label="New Password"
+              placeholder="Enter new password"
+              error={passwordErrors.newPassword?.message}
+              {...registerPassword("newPassword")}
+              styles={inputStyles}
+            />
+            <PasswordInput
+              label="Confirm Password"
+              placeholder="Confirm new password"
+              error={passwordErrors.confirmPassword?.message}
+              {...registerPassword("confirmPassword")}
+              styles={inputStyles}
+            />
+            <Group mt="xl" mb="sm">
+              <Button size="sm" color="gray" onClick={() => setStep(2)}>
+                Back
+              </Button>
+              <Button
+                type="submit"
+                size="sm"
+                style={formStyles.submitButton}
+                loading={isResettingPassword}
+              >
+                Reset Password
+              </Button>
+            </Group>
+          </form>
+        )}
+      </Box>
+    </Modal>
+  );
+};
+
+export default ForgetPasswordModal;

--- a/modules/Login/components/LoginForm.tsx
+++ b/modules/Login/components/LoginForm.tsx
@@ -6,6 +6,7 @@ import { TextInput, PasswordInput } from "react-hook-form-mantine";
 
 import RegisterModal from "@/modules/Landing/components/RegisterModal/RegisterModal";
 
+import ForgetPasswordModal from "./ForgetPasswordModal/ForgetPasswordModal";
 import { LoginFormSchemaResolver, loginFormDefaultValues } from "./LoginForm.helpers";
 import { ILoginFormProps, ILoginFormValues } from "./LoginForm.types";
 
@@ -19,6 +20,7 @@ const LoginForm: React.FC<ILoginFormProps> = ({ onSubmit }) => {
     resolver: LoginFormSchemaResolver,
   });
   const [isRegisterModalOpen, setIsRegisterModalOpen] = useState(false);
+  const [isPasswordResetModalOpen, setIsPasswordResetModalOpen] = useState(false);
 
   const openRegisterModal = () => {
     setIsRegisterModalOpen(true);
@@ -26,6 +28,14 @@ const LoginForm: React.FC<ILoginFormProps> = ({ onSubmit }) => {
 
   const closeRegisterModal = () => {
     setIsRegisterModalOpen(false);
+  };
+
+  const openPasswordResetModal = () => {
+    setIsPasswordResetModalOpen(true);
+  };
+
+  const closePasswordResetModal = () => {
+    setIsPasswordResetModalOpen(false);
   };
 
   return (
@@ -75,7 +85,9 @@ const LoginForm: React.FC<ILoginFormProps> = ({ onSubmit }) => {
         </form>
 
         <Text fw={400} ta="center" my="xs" size="md">
-          <Anchor c="#4CAF50">Forgot Password?</Anchor>
+          <Anchor c="#4CAF50" onClick={openPasswordResetModal}>
+            Forgot Password?
+          </Anchor>
         </Text>
 
         <Text fw={400} c="#4CAF50" ta="center" size="md" mt="xl">
@@ -85,6 +97,7 @@ const LoginForm: React.FC<ILoginFormProps> = ({ onSubmit }) => {
           </Anchor>
         </Text>
         <RegisterModal opened={isRegisterModalOpen} close={closeRegisterModal} />
+        <ForgetPasswordModal opened={isPasswordResetModalOpen} onClose={closePasswordResetModal} />
       </Box>
     </Flex>
   );

--- a/shared/redux/rtk-apis/auth/auth.api.ts
+++ b/shared/redux/rtk-apis/auth/auth.api.ts
@@ -31,8 +31,38 @@ const authApi = projectApi.injectEndpoints({
         body: data,
       }),
     }),
+    generateResetPasswordOtp: builder.mutation<void, { email: string }>({
+      query: (data) => ({
+        url: "auth/forget-password/generate-otp",
+        method: "POST",
+        body: data,
+      }),
+    }),
+
+    validateOtp: builder.mutation<{ isValid: boolean }, { email: string; otp: string }>({
+      query: (data) => ({
+        url: "auth/forget-password/validate-otp",
+        method: "POST",
+        body: data,
+      }),
+    }),
+
+    resetPassword: builder.mutation<boolean, { email: string; otp: string; newPassword: string }>({
+      query: (data) => ({
+        url: "auth/forget-password",
+        method: "POST",
+        body: data,
+      }),
+    }),
   }),
   overrideExisting: false,
 });
 
-export const { useLoginMutation, useRegisterStudentMutation, useRegisterTeacherMutation } = authApi;
+export const {
+  useLoginMutation,
+  useRegisterStudentMutation,
+  useRegisterTeacherMutation,
+  useGenerateResetPasswordOtpMutation,
+  useResetPasswordMutation,
+  useValidateOtpMutation,
+} = authApi;


### PR DESCRIPTION
## Description of Change
- Integrated the necessary api for forget password
- Updated the LoginForm 
- Created ForgetPasswordModal and implemented multi-step
- Created separate file for zod and styles

## Associated Ticket Link(s)
- https://trello.com/c/070J6YSv

## Screenshots / Screen Recordings

<img width="1440" alt="Screen Shot 2024-09-30 at 2 33 19 PM" src="https://github.com/user-attachments/assets/f5c9e2cd-e29c-4ebd-8381-12b9b82f0015">
<img width="1440" alt="Screen Shot 2024-09-30 at 2 34 03 PM" src="https://github.com/user-attachments/assets/e345d173-a2a2-4a94-b504-0ca0aad521db">
<img width="1440" alt="Screen Shot 2024-09-30 at 2 33 49 PM" src="https://github.com/user-attachments/assets/d492ae09-43c2-4553-859e-b9caf4a64726">
