### PR TITLE
feat(ST-173): integrate reset-password endpoint with form modal

### DIFF
--- a/modules/Profile/components/ResetPasswordFormModal/ResetPasswordFormModal.helpers.ts
+++ b/modules/Profile/components/ResetPasswordFormModal/ResetPasswordFormModal.helpers.ts
@@ -1,0 +1,17 @@
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+
+export const resetPasswordSchema = z
+  .object({
+    oldPassword: z.string().min(1, { message: "Old password is required" }),
+    newPassword: z.string().min(8, { message: "Password must be at least 8 characters long" }),
+    confirmPassword: z.string().min(1, { message: "Confirm password is required" }),
+  })
+  .refine((data) => data.newPassword === data.confirmPassword, {
+    message: "Passwords don't match",
+    path: ["confirmPassword"],
+  });
+
+export type TResetPasswordFormValues = z.infer<typeof resetPasswordSchema>;
+
+export const ResetPasswordFormResolver = zodResolver(resetPasswordSchema);

--- a/modules/Profile/components/ResetPasswordFormModal/ResetPasswordFormModal.interface.ts
+++ b/modules/Profile/components/ResetPasswordFormModal/ResetPasswordFormModal.interface.ts
@@ -1,0 +1,4 @@
+export interface IResetPasswordFormModalProps {
+  opened: boolean;
+  onClose: () => void;
+}

--- a/modules/Profile/components/ResetPasswordFormModal/ResetPasswordFormModal.styles.ts
+++ b/modules/Profile/components/ResetPasswordFormModal/ResetPasswordFormModal.styles.ts
@@ -1,0 +1,20 @@
+import { createStyles } from "@mantine/core";
+
+export const useStyles = createStyles((theme) => ({
+  formStyles: {
+    label: {
+      color: "#4CAF50",
+    },
+  },
+  buttonStyles: {
+    backgroundColor: "#4CAF50",
+    color: "white",
+  },
+  titleText: {
+    marginBottom: 20,
+    fontWeight: 700,
+    textTransform: "uppercase",
+    fontSize: theme.fontSizes.lg,
+    color: "#4CAF50",
+  },
+}));

--- a/modules/Profile/components/ResetPasswordFormModal/ResetPasswordFormModal.tsx
+++ b/modules/Profile/components/ResetPasswordFormModal/ResetPasswordFormModal.tsx
@@ -1,0 +1,114 @@
+import { Modal, Box, Text, SimpleGrid, Button, Group } from "@mantine/core";
+import { notifications } from "@mantine/notifications";
+import { useForm } from "react-hook-form";
+import { PasswordInput } from "react-hook-form-mantine";
+
+import { ApiError } from "@/modules/Login/containers/LoginContainer.types";
+import { useResetPasswordMutation } from "@/shared/redux/rtk-apis/users/users.api";
+
+import {
+  ResetPasswordFormResolver,
+  TResetPasswordFormValues,
+} from "./ResetPasswordFormModal.helpers";
+import { IResetPasswordFormModalProps } from "./ResetPasswordFormModal.interface";
+import { useStyles } from "./ResetPasswordFormModal.styles";
+
+const ResetPasswordFormModal: React.FC<IResetPasswordFormModalProps> = ({ opened, onClose }) => {
+  const [resetPassword, { isLoading }] = useResetPasswordMutation();
+  const { classes } = useStyles();
+
+  const {
+    control,
+    handleSubmit,
+    formState: { errors, isValid },
+    reset,
+  } = useForm<TResetPasswordFormValues>({
+    resolver: ResetPasswordFormResolver,
+    mode: "onChange",
+  });
+
+  const onSubmit = async (data: TResetPasswordFormValues) => {
+    try {
+      await resetPassword({
+        oldPassword: data.oldPassword,
+        newPassword: data.newPassword,
+      }).unwrap();
+
+      notifications.show({
+        color: "blue",
+        title: "Success",
+        message: "Password reset successfully",
+      });
+      reset();
+      onClose();
+    } catch (error) {
+      notifications.show({
+        color: "red",
+        title: "Error",
+        message: (error as ApiError).data?.message,
+      });
+    }
+  };
+
+  const handleCancel = () => {
+    reset();
+    onClose();
+  };
+
+  return (
+    <Modal opened={opened} onClose={handleCancel} size="md" centered>
+      <Box mx="xl">
+        <Text mb={20} fw={700} tt="uppercase" size="lg" c={"#4CAF50"}>
+          Reset Password
+        </Text>
+        <form onSubmit={handleSubmit(onSubmit)}>
+          <SimpleGrid>
+            <PasswordInput
+              size="md"
+              label="Old Password"
+              placeholder="Enter your old password"
+              control={control}
+              name="oldPassword"
+              error={errors.oldPassword?.message}
+              className={classes.formStyles}
+            />
+            <PasswordInput
+              size="md"
+              label="New Password"
+              placeholder="Enter your new password"
+              control={control}
+              name="newPassword"
+              error={errors.newPassword?.message}
+              className={classes.formStyles}
+            />
+            <PasswordInput
+              size="md"
+              label="Confirm New Password"
+              placeholder="Confirm your new password"
+              control={control}
+              name="confirmPassword"
+              error={errors.confirmPassword?.message}
+              className={classes.formStyles}
+            />
+          </SimpleGrid>
+          <Group mt="xl" mb="sm" position="right">
+            <Button size="sm" color="gray" onClick={handleCancel}>
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              size="sm"
+              loading={isLoading}
+              className={classes.buttonStyles}
+              disabled={!isValid}
+            >
+              Reset Password
+            </Button>
+          </Group>
+        </form>
+      </Box>
+    </Modal>
+  );
+};
+
+export default ResetPasswordFormModal;

--- a/modules/Profile/containers/ProfileContainer/ProfileContainer.tsx
+++ b/modules/Profile/containers/ProfileContainer/ProfileContainer.tsx
@@ -10,6 +10,7 @@ import { useAppSelector } from "@/shared/redux/hooks";
 import { selectAuthenticatedUser } from "@/shared/redux/reducers/user.reducer";
 import { useGetUserDetailsQuery } from "@/shared/redux/rtk-apis/users/users.api";
 
+import ResetPasswordFormModal from "../../components/ResetPasswordFormModal/ResetPasswordFormModal";
 import StudentProfile from "../../components/StudentProfile/StudentProfile";
 import StudentUpdateProfileForm from "../../components/StudentUpdateProfileForm/StudentUpdateProfileForm";
 import TeacherProfile from "../../components/TeacherProfile/TeacherProfile";
@@ -19,6 +20,7 @@ import { useStyles } from "./ProfileContainer.styles";
 const ProfileContainer = () => {
   const { classes } = useStyles();
   const [isEditing, setIsEditing] = useState(false);
+  const [isResetPasswordModalOpen, setIsResetPasswordModalOpen] = useState(false);
 
   const currentUser = useAppSelector(selectAuthenticatedUser);
 
@@ -59,7 +61,12 @@ const ProfileContainer = () => {
       <SimpleGrid className={classes.container}>
         <Title className={classes.title}>Profile</Title>
         <Flex justify="flex-end" gap="md" align="center">
-          <Button size="compact-md" variant="outline" className={classes.button}>
+          <Button
+            size="compact-md"
+            variant="outline"
+            className={classes.button}
+            onClick={() => setIsResetPasswordModalOpen(true)}
+          >
             Reset Password
           </Button>
           <ActionIcon
@@ -87,6 +94,11 @@ const ProfileContainer = () => {
             <StudentProfile user={user} />
           ))}
       </SimpleGrid>
+
+      <ResetPasswordFormModal
+        opened={isResetPasswordModalOpen}
+        onClose={() => setIsResetPasswordModalOpen(false)}
+      />
     </div>
   );
 };

--- a/shared/redux/rtk-apis/users/users.api.ts
+++ b/shared/redux/rtk-apis/users/users.api.ts
@@ -1,6 +1,6 @@
 import projectApi from "../api.config";
 import { TTokenizedUser } from "../auth/auth.types";
-import { EditableUserFields, IUser } from "./users.types";
+import { EditableUserFields, IUser, IResetPasswordRequest } from "./users.types";
 
 const usersApi = projectApi.injectEndpoints({
   endpoints: (builder) => ({
@@ -21,8 +21,21 @@ const usersApi = projectApi.injectEndpoints({
       }),
       invalidatesTags: ["Profiles"],
     }),
+    resetPassword: builder.mutation<void, IResetPasswordRequest>({
+      query: (resetPasswordData) => ({
+        url: "users/reset-password",
+        method: "PUT",
+        body: resetPasswordData,
+      }),
+    }),
   }),
   overrideExisting: false,
 });
 
-export const { useMeQuery, useLazyMeQuery, useGetUserDetailsQuery, useEditUserMutation } = usersApi;
+export const {
+  useMeQuery,
+  useLazyMeQuery,
+  useGetUserDetailsQuery,
+  useEditUserMutation,
+  useResetPasswordMutation,
+} = usersApi;

--- a/shared/redux/rtk-apis/users/users.types.ts
+++ b/shared/redux/rtk-apis/users/users.types.ts
@@ -38,3 +38,8 @@ export interface EditableUserFields {
   student?: Omit<IStudent, "id">;
   teacher?: Omit<ITeacher, "id">;
 }
+
+export interface IResetPasswordRequest {
+  oldPassword: string;
+  newPassword: string;
+}


### PR DESCRIPTION
## Description of Change
- Created `ResetPasswordFormModal` component.
- Created separate file for zod, interface and styles.
- Updated the `profileContainer` for integrating the `ResetPasswordFormModa`.
- Updated user.api.ts file for integrating the reset password endpoint

## Associated Ticket Link(s)
- https://trello.com/c/yae0gcZA

## Screenshots / Screen Recordings


https://github.com/user-attachments/assets/8ebadee8-6bc4-4ce6-9ae8-f00c42b52cc4



